### PR TITLE
Extract enum values as constants

### DIFF
--- a/src/main/java/io/airlift/units/DataSize.java
+++ b/src/main/java/io/airlift/units/DataSize.java
@@ -32,6 +32,12 @@ public class DataSize
 {
     private static final Pattern PATTERN = Pattern.compile("^\\s*(\\d+(?:\\.\\d+)?)\\s*([a-zA-Z]+)\\s*$");
 
+    // We iterate over the DATASIZE_UNITS constant in convertToMostSuccinctDataSize()
+    // instead of Unit.values() as the latter results in non-trivial amount of memory
+    // allocation when that method is called in a tight loop. The reason is that the values()
+    // call allocates a new array at each call.
+    private static final Unit[] DATASIZE_UNITS = Unit.values();
+
     public static DataSize succinctBytes(long bytes)
     {
         return succinctDataSize(bytes, Unit.BYTE);
@@ -95,7 +101,7 @@ public class DataSize
     public DataSize convertToMostSuccinctDataSize()
     {
         Unit unitToUse = Unit.BYTE;
-        for (Unit unitToTest : Unit.values()) {
+        for (Unit unitToTest : DATASIZE_UNITS) {
             if (getValue(unitToTest) >= 1.0) {
                 unitToUse = unitToTest;
             }

--- a/src/main/java/io/airlift/units/Duration.java
+++ b/src/main/java/io/airlift/units/Duration.java
@@ -38,6 +38,12 @@ public final class Duration
 {
     private static final Pattern PATTERN = Pattern.compile("^\\s*(\\d+(?:\\.\\d+)?)\\s*([a-zA-Z]+)\\s*$");
 
+    // We iterate over the TIME_UNITS constant in convertToMostSuccinctTimeUnit()
+    // instead of TimeUnit.values() as the latter results in non-trivial amount of memory
+    // allocation when that method is called in a tight loop. The reason is that the values()
+    // call allocates a new array at each call.
+    private static final TimeUnit[] TIME_UNITS = TimeUnit.values();
+
     public static Duration nanosSince(long start)
     {
         return succinctNanos(System.nanoTime() - start);
@@ -106,7 +112,7 @@ public final class Duration
     public Duration convertToMostSuccinctTimeUnit()
     {
         TimeUnit unitToUse = NANOSECONDS;
-        for (TimeUnit unitToTest : TimeUnit.values()) {
+        for (TimeUnit unitToTest : TIME_UNITS) {
             // since time units are powers of ten, we can get rounding errors here, so fuzzy match
             if (getValue(unitToTest) > 0.9999) {
                 unitToUse = unitToTest;


### PR DESCRIPTION
Calling these methods in a tight loop results in non-trivial amount of
memory allocation as the values() method allocates a new array at each
call. This change fixes that by extracting these arrays as constants.

More details: https://github.com/prestodb/presto/pull/11112