### PR TITLE
Allow validation annotations in more places

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -12,7 +12,7 @@
     <parent>
         <groupId>io.airlift</groupId>
         <artifactId>airbase</artifactId>
-        <version>82</version>
+        <version>91</version>
     </parent>
 
     <inceptionYear>2016</inceptionYear>

--- a/src/main/java/io/airlift/units/MaxDataSize.java
+++ b/src/main/java/io/airlift/units/MaxDataSize.java
@@ -21,10 +21,14 @@ import java.lang.annotation.Retention;
 import java.lang.annotation.Target;
 
 import static java.lang.annotation.ElementType.ANNOTATION_TYPE;
+import static java.lang.annotation.ElementType.CONSTRUCTOR;
+import static java.lang.annotation.ElementType.FIELD;
 import static java.lang.annotation.ElementType.METHOD;
+import static java.lang.annotation.ElementType.PARAMETER;
+import static java.lang.annotation.ElementType.TYPE_USE;
 import static java.lang.annotation.RetentionPolicy.RUNTIME;
 
-@Target({METHOD, ANNOTATION_TYPE})
+@Target({METHOD, FIELD, ANNOTATION_TYPE, CONSTRUCTOR, PARAMETER, TYPE_USE})
 @Retention(RUNTIME)
 @Documented
 @Constraint(validatedBy = MaxDataSizeValidator.class)

--- a/src/main/java/io/airlift/units/MaxDuration.java
+++ b/src/main/java/io/airlift/units/MaxDuration.java
@@ -23,10 +23,14 @@ import java.lang.annotation.Retention;
 import java.lang.annotation.Target;
 
 import static java.lang.annotation.ElementType.ANNOTATION_TYPE;
+import static java.lang.annotation.ElementType.CONSTRUCTOR;
+import static java.lang.annotation.ElementType.FIELD;
 import static java.lang.annotation.ElementType.METHOD;
+import static java.lang.annotation.ElementType.PARAMETER;
+import static java.lang.annotation.ElementType.TYPE_USE;
 import static java.lang.annotation.RetentionPolicy.RUNTIME;
 
-@Target({METHOD, ANNOTATION_TYPE})
+@Target({METHOD, FIELD, ANNOTATION_TYPE, CONSTRUCTOR, PARAMETER, TYPE_USE})
 @Retention(RUNTIME)
 @Documented
 @Constraint(validatedBy = MaxDurationValidator.class)

--- a/src/main/java/io/airlift/units/MinDataSize.java
+++ b/src/main/java/io/airlift/units/MinDataSize.java
@@ -21,10 +21,14 @@ import java.lang.annotation.Retention;
 import java.lang.annotation.Target;
 
 import static java.lang.annotation.ElementType.ANNOTATION_TYPE;
+import static java.lang.annotation.ElementType.CONSTRUCTOR;
+import static java.lang.annotation.ElementType.FIELD;
 import static java.lang.annotation.ElementType.METHOD;
+import static java.lang.annotation.ElementType.PARAMETER;
+import static java.lang.annotation.ElementType.TYPE_USE;
 import static java.lang.annotation.RetentionPolicy.RUNTIME;
 
-@Target({METHOD, ANNOTATION_TYPE})
+@Target({METHOD, FIELD, ANNOTATION_TYPE, CONSTRUCTOR, PARAMETER, TYPE_USE})
 @Retention(RUNTIME)
 @Documented
 @Constraint(validatedBy = MinDataSizeValidator.class)

--- a/src/main/java/io/airlift/units/MinDuration.java
+++ b/src/main/java/io/airlift/units/MinDuration.java
@@ -23,10 +23,14 @@ import java.lang.annotation.Retention;
 import java.lang.annotation.Target;
 
 import static java.lang.annotation.ElementType.ANNOTATION_TYPE;
+import static java.lang.annotation.ElementType.CONSTRUCTOR;
+import static java.lang.annotation.ElementType.FIELD;
 import static java.lang.annotation.ElementType.METHOD;
+import static java.lang.annotation.ElementType.PARAMETER;
+import static java.lang.annotation.ElementType.TYPE_USE;
 import static java.lang.annotation.RetentionPolicy.RUNTIME;
 
-@Target({METHOD, ANNOTATION_TYPE})
+@Target({METHOD, FIELD, ANNOTATION_TYPE, CONSTRUCTOR, PARAMETER, TYPE_USE})
 @Retention(RUNTIME)
 @Documented
 @Constraint(validatedBy = MinDurationValidator.class)

--- a/src/main/resources/ValidationMessages.properties
+++ b/src/main/resources/ValidationMessages.properties
@@ -1,0 +1,4 @@
+io.airlift.units.MinDuration.message=must be greater than or equal to {value}
+io.airlift.units.MaxDuration.message=must be less than or equal to {value}
+io.airlift.units.MinDataSize.message=must be greater than or equal to {value}
+io.airlift.units.MaxDataSize.message=must be less than or equal to {value}

--- a/src/test/java/io/airlift/units/ConstraintValidatorAssert.java
+++ b/src/test/java/io/airlift/units/ConstraintValidatorAssert.java
@@ -15,6 +15,7 @@ package io.airlift.units;
 
 import org.assertj.core.api.AbstractAssert;
 
+import javax.validation.ClockProvider;
 import javax.validation.ConstraintValidator;
 import javax.validation.ConstraintValidatorContext;
 
@@ -60,6 +61,12 @@ final class ConstraintValidatorAssert<A extends Annotation, T>
 
         @Override
         public String getDefaultConstraintMessageTemplate()
+        {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public ClockProvider getClockProvider()
         {
             throw new UnsupportedOperationException();
         }

--- a/src/test/java/io/airlift/units/TestDataSizeValidator.java
+++ b/src/test/java/io/airlift/units/TestDataSizeValidator.java
@@ -21,6 +21,7 @@ import javax.validation.Validation;
 import javax.validation.ValidationException;
 import javax.validation.Validator;
 
+import java.util.Optional;
 import java.util.Set;
 
 import static io.airlift.units.ConstraintValidatorAssert.assertThat;
@@ -83,12 +84,30 @@ public class TestDataSizeValidator
                 .isInstanceOf(ValidationException.class)
                 .hasRootCauseInstanceOf(IllegalArgumentException.class)
                 .hasMessage("java.lang.IllegalArgumentException: size is not a valid data size string: broken");
+
+        assertThatThrownBy(() -> VALIDATOR.validate(new MinAnnotationOnOptional()))
+                .isInstanceOf(ValidationException.class)
+                .hasMessage("No compliant io.airlift.units.MinDataSize ConstraintValidator found for annotated element of type java.util.Optional<T>");
+
+        assertThatThrownBy(() -> VALIDATOR.validate(new BrokenOptionalMinAnnotation()))
+                .isInstanceOf(ValidationException.class)
+                .hasRootCauseInstanceOf(IllegalArgumentException.class)
+                .hasMessage("java.lang.IllegalArgumentException: size is not a valid data size string: broken");
     }
 
     @Test
     public void testDetectsBrokenMaxAnnotation()
     {
         assertThatThrownBy(() -> VALIDATOR.validate(new BrokenMaxAnnotation()))
+                .isInstanceOf(ValidationException.class)
+                .hasRootCauseInstanceOf(IllegalArgumentException.class)
+                .hasMessage("java.lang.IllegalArgumentException: size is not a valid data size string: broken");
+
+        assertThatThrownBy(() -> VALIDATOR.validate(new MaxAnnotationOnOptional()))
+                .isInstanceOf(ValidationException.class)
+                .hasMessage("No compliant io.airlift.units.MaxDataSize ConstraintValidator found for annotated element of type java.util.Optional<T>");
+
+        assertThatThrownBy(() -> VALIDATOR.validate(new BrokenOptionalMaxAnnotation()))
                 .isInstanceOf(ValidationException.class)
                 .hasRootCauseInstanceOf(IllegalArgumentException.class)
                 .hasMessage("java.lang.IllegalArgumentException: size is not a valid data size string: broken");
@@ -99,6 +118,15 @@ public class TestDataSizeValidator
     {
         assertTrue(VALIDATOR.validate(new ConstrainedDataSize(new DataSize(7, MEGABYTE)))
                 .isEmpty());
+
+        assertThat(VALIDATOR.validate(new ConstrainedOptionalDataSize(Optional.of(new DataSize(7, MEGABYTE)))))
+                .isEmpty();
+
+        assertThat(VALIDATOR.validate(new ConstrainedOptionalDataSize(Optional.empty())))
+                .isEmpty();
+
+        assertThat(VALIDATOR.validate(new ConstrainedOptionalDataSize(null)))
+                .isEmpty();
     }
 
     @Test
@@ -110,12 +138,26 @@ public class TestDataSizeValidator
                 .allMatch(MaxDataSize.class::isInstance);
         assertThat(violations.stream().map(violation -> violation.getPropertyPath().toString()))
                 .containsOnly("constrainedByMax", "constrainedByMinAndMax");
+
+        violations = VALIDATOR.validate(new ConstrainedOptionalDataSize(Optional.of(new DataSize(11, MEGABYTE))));
+        assertThat(violations).hasSize(2);
+        assertThat(violations.stream().map(violation -> violation.getConstraintDescriptor().getAnnotation()))
+                .allMatch(MaxDataSize.class::isInstance);
+        assertThat(violations.stream().map(violation -> violation.getPropertyPath().toString()))
+                .containsOnly("constrainedByMax", "constrainedByMinAndMax");
     }
 
     @Test
     public void testFailsMinDataSizeConstraint()
     {
         Set<? extends ConstraintViolation<?>> violations = VALIDATOR.validate(new ConstrainedDataSize(new DataSize(1, MEGABYTE)));
+        assertThat(violations).hasSize(2);
+        assertThat(violations.stream().map(violation -> violation.getConstraintDescriptor().getAnnotation()))
+                .allMatch(MinDataSize.class::isInstance);
+        assertThat(violations.stream().map(violation -> violation.getPropertyPath().toString()))
+                .containsOnly("constrainedByMin", "constrainedByMinAndMax");
+
+        violations = VALIDATOR.validate(new ConstrainedOptionalDataSize(Optional.of(new DataSize(1, MEGABYTE))));
         assertThat(violations).hasSize(2);
         assertThat(violations.stream().map(violation -> violation.getConstraintDescriptor().getAnnotation()))
                 .allMatch(MinDataSize.class::isInstance);
@@ -148,6 +190,32 @@ public class TestDataSizeValidator
         @MinDataSize("5000kB")
         @MaxDataSize("10000kB")
         public DataSize getConstrainedByMinAndMax()
+        {
+            return dataSize;
+        }
+    }
+
+    @SuppressWarnings("UnusedDeclaration")
+    public static class ConstrainedOptionalDataSize
+    {
+        private final Optional<DataSize> dataSize;
+
+        public ConstrainedOptionalDataSize(Optional<DataSize> dataSize)
+        {
+            this.dataSize = dataSize;
+        }
+
+        public Optional<@MinDataSize("5MB") DataSize> getConstrainedByMin()
+        {
+            return dataSize;
+        }
+
+        public Optional<@MaxDataSize("10MB") DataSize> getConstrainedByMax()
+        {
+            return dataSize;
+        }
+
+        public Optional<@MinDataSize("5000kB") @MaxDataSize("10000kB") DataSize> getConstrainedByMinAndMax()
         {
             return dataSize;
         }
@@ -190,6 +258,44 @@ public class TestDataSizeValidator
         public DataSize getConstrainedByMin()
         {
             return new DataSize(32, KILOBYTE);
+        }
+    }
+
+    public static class MinAnnotationOnOptional
+    {
+        @SuppressWarnings("UnusedDeclaration")
+        @MinDataSize("1MB")
+        public Optional<DataSize> getConstrainedByMin()
+        {
+            return Optional.empty();
+        }
+    }
+
+    public static class MaxAnnotationOnOptional
+    {
+        @SuppressWarnings("UnusedDeclaration")
+        @MaxDataSize("1MB")
+        public Optional<DataSize> getConstrainedByMin()
+        {
+            return Optional.empty();
+        }
+    }
+
+    public static class BrokenOptionalMinAnnotation
+    {
+        @SuppressWarnings("UnusedDeclaration")
+        public Optional<@MinDataSize("broken") DataSize> getConstrainedByMin()
+        {
+            return Optional.empty();
+        }
+    }
+
+    public static class BrokenOptionalMaxAnnotation
+    {
+        @SuppressWarnings("UnusedDeclaration")
+        public Optional<@MaxDataSize("broken") DataSize> getConstrainedByMax()
+        {
+            return Optional.empty();
         }
     }
 }

--- a/src/test/java/io/airlift/units/TestDataSizeValidator.java
+++ b/src/test/java/io/airlift/units/TestDataSizeValidator.java
@@ -138,6 +138,8 @@ public class TestDataSizeValidator
                 .allMatch(MaxDataSize.class::isInstance);
         assertThat(violations.stream().map(violation -> violation.getPropertyPath().toString()))
                 .containsOnly("constrainedByMax", "constrainedByMinAndMax");
+        assertThat(violations.stream().map(ConstraintViolation::getMessage))
+                .containsOnly("must be less than or equal to 10000kB", "must be less than or equal to 10MB");
 
         violations = VALIDATOR.validate(new ConstrainedOptionalDataSize(Optional.of(new DataSize(11, MEGABYTE))));
         assertThat(violations).hasSize(2);
@@ -145,6 +147,8 @@ public class TestDataSizeValidator
                 .allMatch(MaxDataSize.class::isInstance);
         assertThat(violations.stream().map(violation -> violation.getPropertyPath().toString()))
                 .containsOnly("constrainedByMax", "constrainedByMinAndMax");
+        assertThat(violations.stream().map(ConstraintViolation::getMessage))
+                .containsOnly("must be less than or equal to 10000kB", "must be less than or equal to 10MB");
     }
 
     @Test
@@ -156,6 +160,8 @@ public class TestDataSizeValidator
                 .allMatch(MinDataSize.class::isInstance);
         assertThat(violations.stream().map(violation -> violation.getPropertyPath().toString()))
                 .containsOnly("constrainedByMin", "constrainedByMinAndMax");
+        assertThat(violations.stream().map(ConstraintViolation::getMessage))
+                .containsOnly("must be greater than or equal to 5MB", "must be greater than or equal to 5000kB");
 
         violations = VALIDATOR.validate(new ConstrainedOptionalDataSize(Optional.of(new DataSize(1, MEGABYTE))));
         assertThat(violations).hasSize(2);
@@ -163,6 +169,8 @@ public class TestDataSizeValidator
                 .allMatch(MinDataSize.class::isInstance);
         assertThat(violations.stream().map(violation -> violation.getPropertyPath().toString()))
                 .containsOnly("constrainedByMin", "constrainedByMinAndMax");
+        assertThat(violations.stream().map(ConstraintViolation::getMessage))
+                .containsOnly("must be greater than or equal to 5MB", "must be greater than or equal to 5000kB");
     }
 
     @SuppressWarnings("UnusedDeclaration")

--- a/src/test/java/io/airlift/units/TestDurationValidator.java
+++ b/src/test/java/io/airlift/units/TestDurationValidator.java
@@ -23,6 +23,7 @@ import javax.validation.Validation;
 import javax.validation.ValidationException;
 import javax.validation.Validator;
 
+import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
 
@@ -75,6 +76,15 @@ public class TestDurationValidator
                 .isInstanceOf(ValidationException.class)
                 .hasRootCauseInstanceOf(IllegalArgumentException.class)
                 .hasMessage("java.lang.IllegalArgumentException: duration is not a valid data duration string: broken");
+
+        assertThatThrownBy(() -> VALIDATOR.validate(new MinAnnotationOnOptional()))
+                .isInstanceOf(ValidationException.class)
+                .hasMessage("No compliant io.airlift.units.MinDuration ConstraintValidator found for annotated element of type java.util.Optional<T>");
+
+        assertThatThrownBy(() -> VALIDATOR.validate(new BrokenOptionalMinAnnotation()))
+                .isInstanceOf(ValidationException.class)
+                .hasRootCauseInstanceOf(IllegalArgumentException.class)
+                .hasMessage("java.lang.IllegalArgumentException: duration is not a valid data duration string: broken");
     }
 
     @Test
@@ -84,12 +94,30 @@ public class TestDurationValidator
                 .isInstanceOf(ValidationException.class)
                 .hasRootCauseInstanceOf(IllegalArgumentException.class)
                 .hasMessage("java.lang.IllegalArgumentException: duration is not a valid data duration string: broken");
+
+        assertThatThrownBy(() -> VALIDATOR.validate(new MaxAnnotationOnOptional()))
+                .isInstanceOf(ValidationException.class)
+                .hasMessage("No compliant io.airlift.units.MaxDuration ConstraintValidator found for annotated element of type java.util.Optional<T>");
+
+        assertThatThrownBy(() -> VALIDATOR.validate(new BrokenOptionalMaxAnnotation()))
+                .isInstanceOf(ValidationException.class)
+                .hasRootCauseInstanceOf(IllegalArgumentException.class)
+                .hasMessage("java.lang.IllegalArgumentException: duration is not a valid data duration string: broken");
     }
 
     @Test
     public void testPassesValidation()
     {
         assertThat(VALIDATOR.validate(new ConstrainedDuration(new Duration(7, TimeUnit.SECONDS))))
+                .isEmpty();
+
+        assertThat(VALIDATOR.validate(new ConstrainedOptionalDuration(Optional.of(new Duration(7, TimeUnit.SECONDS)))))
+                .isEmpty();
+
+        assertThat(VALIDATOR.validate(new ConstrainedOptionalDuration(Optional.empty())))
+                .isEmpty();
+
+        assertThat(VALIDATOR.validate(new ConstrainedOptionalDuration(null)))
                 .isEmpty();
     }
 
@@ -102,12 +130,26 @@ public class TestDurationValidator
                 .allMatch(MaxDuration.class::isInstance);
         assertThat(violations.stream().map(violation -> violation.getPropertyPath().toString()))
                 .containsOnly("constrainedByMax", "constrainedByMinAndMax");
+
+        violations = VALIDATOR.validate(new ConstrainedOptionalDuration(Optional.of(new Duration(11, TimeUnit.SECONDS))));
+        assertThat(violations).hasSize(2);
+        assertThat(violations.stream().map(violation -> violation.getConstraintDescriptor().getAnnotation()))
+                .allMatch(MaxDuration.class::isInstance);
+        assertThat(violations.stream().map(violation -> violation.getPropertyPath().toString()))
+                .containsOnly("constrainedByMax", "constrainedByMinAndMax");
     }
 
     @Test
     public void testFailsMinDurationConstraint()
     {
         Set<? extends ConstraintViolation<?>> violations = VALIDATOR.validate(new ConstrainedDuration(new Duration(1, TimeUnit.SECONDS)));
+        assertThat(violations).hasSize(2);
+        assertThat(violations.stream().map(violation -> violation.getConstraintDescriptor().getAnnotation()))
+                .allMatch(MinDuration.class::isInstance);
+        assertThat(violations.stream().map(violation -> violation.getPropertyPath().toString()))
+                .containsOnly("constrainedByMin", "constrainedByMinAndMax");
+
+        violations = VALIDATOR.validate(new ConstrainedOptionalDuration(Optional.of(new Duration(1, TimeUnit.SECONDS))));
         assertThat(violations).hasSize(2);
         assertThat(violations.stream().map(violation -> violation.getConstraintDescriptor().getAnnotation()))
                 .allMatch(MinDuration.class::isInstance);
@@ -140,6 +182,32 @@ public class TestDurationValidator
         @MinDuration("5000ms")
         @MaxDuration("10000ms")
         public Duration getConstrainedByMinAndMax()
+        {
+            return duration;
+        }
+    }
+
+    @SuppressWarnings("UnusedDeclaration")
+    public static class ConstrainedOptionalDuration
+    {
+        private final Optional<Duration> duration;
+
+        public ConstrainedOptionalDuration(Optional<Duration> duration)
+        {
+            this.duration = duration;
+        }
+
+        public Optional<@MinDuration("5s") Duration> getConstrainedByMin()
+        {
+            return duration;
+        }
+
+        public Optional<@MaxDuration("10s") Duration> getConstrainedByMax()
+        {
+            return duration;
+        }
+
+        public Optional<@MinDuration("5000ms") @MaxDuration("10000ms") Duration> getConstrainedByMinAndMax()
         {
             return duration;
         }
@@ -182,6 +250,44 @@ public class TestDurationValidator
         public Duration getConstrainedByMin()
         {
             return new Duration(10, TimeUnit.SECONDS);
+        }
+    }
+
+    public static class MinAnnotationOnOptional
+    {
+        @SuppressWarnings("UnusedDeclaration")
+        @MinDuration("1s")
+        public Optional<Duration> getConstrainedByMin()
+        {
+            return Optional.empty();
+        }
+    }
+
+    public static class MaxAnnotationOnOptional
+    {
+        @SuppressWarnings("UnusedDeclaration")
+        @MaxDuration("1s")
+        public Optional<Duration> getConstrainedByMin()
+        {
+            return Optional.empty();
+        }
+    }
+
+    public static class BrokenOptionalMinAnnotation
+    {
+        @SuppressWarnings("UnusedDeclaration")
+        public Optional<@MinDuration("broken") Duration> getConstrainedByMin()
+        {
+            return Optional.empty();
+        }
+    }
+
+    public static class BrokenOptionalMaxAnnotation
+    {
+        @SuppressWarnings("UnusedDeclaration")
+        public Optional<@MaxDuration("broken") Duration> getConstrainedByMax()
+        {
+            return Optional.empty();
         }
     }
 }

--- a/src/test/java/io/airlift/units/TestDurationValidator.java
+++ b/src/test/java/io/airlift/units/TestDurationValidator.java
@@ -130,6 +130,8 @@ public class TestDurationValidator
                 .allMatch(MaxDuration.class::isInstance);
         assertThat(violations.stream().map(violation -> violation.getPropertyPath().toString()))
                 .containsOnly("constrainedByMax", "constrainedByMinAndMax");
+        assertThat(violations.stream().map(ConstraintViolation::getMessage))
+                .containsOnly("must be less than or equal to 10s", "must be less than or equal to 10000ms");
 
         violations = VALIDATOR.validate(new ConstrainedOptionalDuration(Optional.of(new Duration(11, TimeUnit.SECONDS))));
         assertThat(violations).hasSize(2);
@@ -137,6 +139,8 @@ public class TestDurationValidator
                 .allMatch(MaxDuration.class::isInstance);
         assertThat(violations.stream().map(violation -> violation.getPropertyPath().toString()))
                 .containsOnly("constrainedByMax", "constrainedByMinAndMax");
+        assertThat(violations.stream().map(ConstraintViolation::getMessage))
+                .containsOnly("must be less than or equal to 10s", "must be less than or equal to 10000ms");
     }
 
     @Test
@@ -148,6 +152,8 @@ public class TestDurationValidator
                 .allMatch(MinDuration.class::isInstance);
         assertThat(violations.stream().map(violation -> violation.getPropertyPath().toString()))
                 .containsOnly("constrainedByMin", "constrainedByMinAndMax");
+        assertThat(violations.stream().map(ConstraintViolation::getMessage))
+                .containsOnly("must be greater than or equal to 5000ms", "must be greater than or equal to 5s");
 
         violations = VALIDATOR.validate(new ConstrainedOptionalDuration(Optional.of(new Duration(1, TimeUnit.SECONDS))));
         assertThat(violations).hasSize(2);
@@ -155,6 +161,8 @@ public class TestDurationValidator
                 .allMatch(MinDuration.class::isInstance);
         assertThat(violations.stream().map(violation -> violation.getPropertyPath().toString()))
                 .containsOnly("constrainedByMin", "constrainedByMinAndMax");
+        assertThat(violations.stream().map(ConstraintViolation::getMessage))
+                .containsOnly("must be greater than or equal to 5000ms", "must be greater than or equal to 5s");
     }
 
     @SuppressWarnings("UnusedDeclaration")

--- a/src/test/java/io/airlift/units/TestDurationValidator.java
+++ b/src/test/java/io/airlift/units/TestDurationValidator.java
@@ -28,11 +28,11 @@ import java.util.concurrent.TimeUnit;
 
 import static io.airlift.units.ConstraintValidatorAssert.assertThat;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.testng.Assert.fail;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 public class TestDurationValidator
 {
-    private static final Validator validator = Validation.byProvider(ApacheValidationProvider.class).configure().buildValidatorFactory().getValidator();
+    private static final Validator VALIDATOR = Validation.byProvider(ApacheValidationProvider.class).configure().buildValidatorFactory().getValidator();
 
     @Test
     public void testMaxDurationValidator()
@@ -59,69 +59,60 @@ public class TestDurationValidator
     @Test
     public void testAllowsNullMinAnnotation()
     {
-        validator.validate(new NullMinAnnotation());
+        VALIDATOR.validate(new NullMinAnnotation());
     }
 
     @Test
     public void testAllowsNullMaxAnnotation()
     {
-        validator.validate(new NullMaxAnnotation());
+        VALIDATOR.validate(new NullMaxAnnotation());
     }
 
     @Test
     public void testDetectsBrokenMinAnnotation()
     {
-        try {
-            validator.validate(new BrokenMinAnnotation());
-            fail("expected a ValidationException caused by an IllegalArgumentException");
-        }
-        catch (ValidationException e) {
-            assertThat(e).hasRootCauseInstanceOf(IllegalArgumentException.class);
-        }
+        assertThatThrownBy(() -> VALIDATOR.validate(new BrokenMinAnnotation()))
+                .isInstanceOf(ValidationException.class)
+                .hasRootCauseInstanceOf(IllegalArgumentException.class)
+                .hasMessage("java.lang.IllegalArgumentException: duration is not a valid data duration string: broken");
     }
 
     @Test
     public void testDetectsBrokenMaxAnnotation()
     {
-        try {
-            validator.validate(new BrokenMaxAnnotation());
-            fail("expected a ValidationException caused by an IllegalArgumentException");
-        }
-        catch (ValidationException e) {
-            assertThat(e).hasRootCauseInstanceOf(IllegalArgumentException.class);
-        }
+        assertThatThrownBy(() -> VALIDATOR.validate(new BrokenMaxAnnotation()))
+                .isInstanceOf(ValidationException.class)
+                .hasRootCauseInstanceOf(IllegalArgumentException.class)
+                .hasMessage("java.lang.IllegalArgumentException: duration is not a valid data duration string: broken");
     }
 
     @Test
     public void testPassesValidation()
     {
-        ConstrainedDuration object = new ConstrainedDuration(new Duration(7, TimeUnit.SECONDS));
-        Set<ConstraintViolation<ConstrainedDuration>> violations = validator.validate(object);
-        assertThat(violations).isEmpty();
+        assertThat(VALIDATOR.validate(new ConstrainedDuration(new Duration(7, TimeUnit.SECONDS))))
+                .isEmpty();
     }
 
     @Test
     public void testFailsMaxDurationConstraint()
     {
-        ConstrainedDuration object = new ConstrainedDuration(new Duration(11, TimeUnit.SECONDS));
-        Set<ConstraintViolation<ConstrainedDuration>> violations = validator.validate(object);
+        Set<? extends ConstraintViolation<?>> violations = VALIDATOR.validate(new ConstrainedDuration(new Duration(11, TimeUnit.SECONDS)));
         assertThat(violations).hasSize(2);
-
-        for (ConstraintViolation<ConstrainedDuration> violation : violations) {
-            assertThat(violation.getConstraintDescriptor().getAnnotation()).isInstanceOf(MaxDuration.class);
-        }
+        assertThat(violations.stream().map(violation -> violation.getConstraintDescriptor().getAnnotation()))
+                .allMatch(MaxDuration.class::isInstance);
+        assertThat(violations.stream().map(violation -> violation.getPropertyPath().toString()))
+                .containsOnly("constrainedByMax", "constrainedByMinAndMax");
     }
 
     @Test
     public void testFailsMinDurationConstraint()
     {
-        ConstrainedDuration object = new ConstrainedDuration(new Duration(1, TimeUnit.SECONDS));
-        Set<ConstraintViolation<ConstrainedDuration>> violations = validator.validate(object);
+        Set<? extends ConstraintViolation<?>> violations = VALIDATOR.validate(new ConstrainedDuration(new Duration(1, TimeUnit.SECONDS)));
         assertThat(violations).hasSize(2);
-
-        for (ConstraintViolation<ConstrainedDuration> violation : violations) {
-            assertThat(violation.getConstraintDescriptor().getAnnotation()).isInstanceOf(MinDuration.class);
-        }
+        assertThat(violations.stream().map(violation -> violation.getConstraintDescriptor().getAnnotation()))
+                .allMatch(MinDuration.class::isInstance);
+        assertThat(violations.stream().map(violation -> violation.getPropertyPath().toString()))
+                .containsOnly("constrainedByMin", "constrainedByMinAndMax");
     }
 
     @SuppressWarnings("UnusedDeclaration")
@@ -154,9 +145,9 @@ public class TestDurationValidator
         }
     }
 
-    @SuppressWarnings("UnusedDeclaration")
     public static class NullMinAnnotation
     {
+        @SuppressWarnings("UnusedDeclaration")
         @MinDuration("1s")
         public Duration getConstrainedByMin()
         {
@@ -164,9 +155,9 @@ public class TestDurationValidator
         }
     }
 
-    @SuppressWarnings("UnusedDeclaration")
     public static class NullMaxAnnotation
     {
+        @SuppressWarnings("UnusedDeclaration")
         @MaxDuration("1s")
         public Duration getConstrainedByMin()
         {
@@ -174,9 +165,9 @@ public class TestDurationValidator
         }
     }
 
-    @SuppressWarnings("UnusedDeclaration")
     public static class BrokenMinAnnotation
     {
+        @SuppressWarnings("UnusedDeclaration")
         @MinDuration("broken")
         public Duration getConstrainedByMin()
         {
@@ -184,9 +175,9 @@ public class TestDurationValidator
         }
     }
 
-    @SuppressWarnings("UnusedDeclaration")
     public static class BrokenMaxAnnotation
     {
+        @SuppressWarnings("UnusedDeclaration")
         @MinDuration("broken")
         public Duration getConstrainedByMin()
         {


### PR DESCRIPTION
Validation 2.0 allows validation annotation to be placed whenever type
is used. Target element types are updated to match the ones currently on
`javax.validation.constraints.Min` annotation.