### PR TITLE
Allow checking whether Duration is zero length

### DIFF
--- a/src/main/java/io/airlift/units/Duration.java
+++ b/src/main/java/io/airlift/units/Duration.java
@@ -46,6 +46,8 @@ public final class Duration
     // call allocates a new array at each call.
     private static final TimeUnit[] TIME_UNITS = TimeUnit.values();
 
+    public static final Duration ZERO = new Duration(0, SECONDS);
+
     public static Duration nanosSince(long start)
     {
         return succinctNanos(System.nanoTime() - start);
@@ -58,6 +60,9 @@ public final class Duration
 
     public static Duration succinctDuration(double value, TimeUnit unit)
     {
+        if (value == 0) {
+            return ZERO;
+        }
         return new Duration(value, unit).convertToMostSuccinctTimeUnit();
     }
 
@@ -191,6 +196,11 @@ public final class Duration
     public int compareTo(Duration o)
     {
         return Double.compare(getValue(MILLISECONDS), o.getValue(MILLISECONDS));
+    }
+
+    public boolean isZero()
+    {
+        return equals(ZERO);
     }
 
     @Override

--- a/src/test/java/io/airlift/units/TestDuration.java
+++ b/src/test/java/io/airlift/units/TestDuration.java
@@ -38,7 +38,9 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.offset;
 import static org.assertj.core.data.Percentage.withPercentage;
 import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
 import static org.testng.Assert.assertNotEquals;
+import static org.testng.Assert.assertTrue;
 import static org.testng.Assert.fail;
 
 public class TestDuration
@@ -292,6 +294,22 @@ public class TestDuration
     {
         assertEquals(new Duration(12359.0d, MILLISECONDS), new Duration(12359.0d, MILLISECONDS));
         assertNotEquals(new Duration(4444.0d, MILLISECONDS), new Duration(12359.0d, MILLISECONDS));
+    }
+
+    @Test
+    public void testIsZero()
+    {
+        assertTrue(Duration.ZERO.isZero());
+        assertTrue(new Duration(0, HOURS).isZero());
+        assertFalse(new Duration(12359.0d, MILLISECONDS).isZero());
+
+        // small values
+        assertFalse(new Duration(1e-20, MILLISECONDS).isZero());
+        assertFalse(new Duration(1e-20, NANOSECONDS).isZero());
+
+        // very small values
+        assertFalse(new Duration(Double.MIN_VALUE, MILLISECONDS).isZero());
+        assertTrue(new Duration(Double.MIN_VALUE, NANOSECONDS).isZero()); // TODO incorrect, due to equals converting to MILLIS
     }
 
     @Test


### PR DESCRIPTION
This introduces new API method for checking whether duration is empty.
The tempting terse alternative of `duration.toMillis() == 0` does not
work correctly for sub-milli duration, so it's better to provide a
shortcut that's correct.